### PR TITLE
Prevent invalid Docker tag generation in PR builds

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'pull_request' }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- disable branch-prefixed SHA tags when the workflow runs for pull_request events to avoid empty prefixes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0255c94208333b5cf6039d1297838