### PR TITLE
fix: copy Alembic migrations to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ COPY --from=builder --chown=botuser:botuser /root/.local /home/botuser/.local
 # Copy application code
 COPY --chown=botuser:botuser bot/ ./bot/
 
+# Copy Alembic migrations
+COPY --chown=botuser:botuser alembic/ ./alembic/
+COPY --chown=botuser:botuser alembic.ini ./
+
 # Create version file
 RUN echo "${VERSION}" > /app/VERSION
 


### PR DESCRIPTION
- Add alembic/ directory and alembic.ini to Docker image
- Enables future database migrations without manual SQL
- Migrations can be applied via 'alembic upgrade head' in container