### PR TITLE
fix: smoke test database connection in CI/CD

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -167,6 +167,11 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "Testing with tag: ${TAG}"
 
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
       - name: Run smoke test
         run: |
           chmod +x tests/smoke-test.sh


### PR DESCRIPTION
- Use host.docker.internal to connect to GitHub Actions postgres service
- Add PostgreSQL client installation for pg_isready check
- Add database readiness check before starting bot container
- Remove incorrect --network=host option

This fixes the 'Temporary failure in name resolution' error during smoke test execution in GitHub Actions.