### PR TITLE
fix: set semantic-release job outputs for GitOps update

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -50,7 +50,19 @@ jobs:
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          npx semantic-release 2>&1 | tee semantic-release.log
+
+          # Parse semantic-release output to set job outputs
+          if grep -q "Published release" semantic-release.log; then
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            VERSION=$(grep "Published release" semantic-release.log | grep -oP '\d+\.\d+\.\d+' | head -1)
+            echo "new_release_version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "✅ New release published: ${VERSION}"
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No new release published"
+          fi
 
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Problem: update-gitops job was skipped because semantic-release outputs (new_release_published, new_release_version) were not set.

Solution: Parse semantic-release output log and extract:
- new_release_published: true if 'Published release' found
- new_release_version: extracted version number (e.g., 1.0.2)

This allows update-gitops job to run when a new release is created.