### PR TITLE
Release v1.1.1: fix user creation with proxies and inbounds

### DIFF
--- a/bot/services/marzban_api.py
+++ b/bot/services/marzban_api.py
@@ -144,12 +144,16 @@ class MarzbanAPI:
             inbounds = available_inbounds
             logger.info(f"Using all available inbounds for user {username}: {inbounds}")
 
+        # Create proxies dict with empty settings for each protocol
+        proxies = {protocol: {} for protocol in inbounds.keys()}
+
         payload = {
             "username": username,
             "status": status,
             "data_limit": data_limit if data_limit is not None else 0,  # 0 = unlimited
             "data_limit_reset_strategy": "no_reset",
             "expire": expire if expire is not None else 0,  # 0 = unlimited
+            "proxies": proxies,
             "inbounds": inbounds,
         }
 


### PR DESCRIPTION
## 🎯 Changes

### Bug Fixes
- **Fix user creation**: Add `proxies` field to user creation payload (resolves 500 errors)
- **Auto-populate inbounds**: Automatically fetch and use all available inbounds from Marzban API
- **Database fixes**: Corrected existing users with empty proxies

### Features
- **About Bot button**: Add ℹ️ О боте button to admin menu for version display

## 🔍 Details

### Root Cause
Marzban API requires **both** `proxies` and `inbounds` fields when creating users:
```json
{
  "proxies": {"vless": {}},
  "inbounds": {"vless": ["VLESS TCP REALITY"]}
}
```

Previously only `inbounds` was sent, causing users to be created without proxies, which led to:
- 500 errors from Marzban API when listing users
- Users appearing in database but not visible in dashboard

### Changes Made
1. Added `get_inbounds()` method to fetch available inbounds from Marzban API
2. Added inbounds caching to reduce API calls
3. Modified `create_user()` to automatically populate both `proxies` and `inbounds`
4. Added detailed logging for debugging
5. Added "About Bot" button to admin keyboard

## ✅ Testing
- Marzban API verified working after fixes
- Existing broken users fixed in database
- New users create successfully with proper VPN configuration